### PR TITLE
BUG-1 reject decimal formatted input and add regression test

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,14 @@ const Roman = ['M', 'CM', 'D', 'CD', 'C', 'XC', 'L', 'XL', 'X', 'IX', 'V', 'IV',
 const arabic = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
 
 const numToRoman = (num) => {
-  num = Number(num);
+    const raw = String(num ?? "").trim()
+    
+    // Reject any decimal format like "2.0" or "2.5"
+    if (raw.includes(".")){
+        return "Please enter a whole number (no decimals).";
+    }
+
+  num = Number(raw);
 
   if (!Number.isFinite(num)) return "Please enter a valid number.";
   if (!Number.isInteger(num)) return "Please enter a whole number (no decimals)."; //validation for decimals

--- a/index.test.js
+++ b/index.test.js
@@ -86,5 +86,10 @@ describe("test that numbers below 1 and above 3999 cannot be converted", () => {
     test("non-numeric input is rejected", () => {
         expect(numToRoman("abc")).toBe("Please enter a valid number.");
     });
+    // test for decimal bug fix - inputting a value of 2.0 is showing as II when romanizing, however it should not accept any decimal values.
+    test("decimal formatted input like 2.0 is rejected", () => {
+        expect(numToRoman("2.0")).toBe("Please enter a whole number (no decimals).");
+    });
+
 });
 })


### PR DESCRIPTION
Closes #7 

Steps to reproduce:
1. Enter 2.0
2. Click Romanize

Expected:
- Show decimal error message

Actual (before fix):
- Converted 2.0 to II

Fix:
- Added failing unit test for "2.0"
- Updated validation to reject decimal formatted input
- All tests passing
<img width="1806" height="774" alt="bug fix successful" src="https://github.com/user-attachments/assets/cb980768-43b2-4dcd-95ea-a6095f2dd943" />
<img width="2493" height="1197" alt="bug evidence failing test" src="https://github.com/user-attachments/assets/d899ee8f-daf1-4bfd-bde9-9c39a2b37673" />
<img width="720" height="390" alt="decimal bug systems testing" src="https://github.com/user-attachments/assets/5ed92f99-8ced-4c37-801e-aac0c22f28ad" />
